### PR TITLE
Renamed RingBuffer to ActionRingBuffer due to name-conflict on Arduino Zero 

### DIFF
--- a/ActionRingBuffer.h
+++ b/ActionRingBuffer.h
@@ -17,31 +17,31 @@
 //    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-// File : RingBuffer.h
+// File : ActionRingBuffer.h
 // Author : Franck Marini
 // Description : Implementation of a generic elements ring buffer
 // Module dependencies : none
 
-#ifndef RINGBUFFER_H
-#define RINGBUFFER_H
+#ifndef ACTIONRINGBUFFER_H
+#define ACTIONRINGBUFFER_H
 
 #include "Arduino.h"
 
 // !!!!!!!!!!!!!!! FLAG OPTIONS !!!!!!!!!!!!!!!!!
-// #define RINGBUFFER_STAT // To be uncommented when doing Statistics
+// #define ACTIONRINGBUFFER_STAT // To be uncommented when doing Statistics
 
 
 // The type of the contained elements and the ring buffer size are defined at compile time (template)
 // In case of buffer full, a new appended data overwrites the oldest one
 
 template<typename T, word size>
-class RingBuffer {
+class ActionRingBuffer {
      byte _head;
      byte _tail;
      T _buffer[size]; // elements buffer
      byte _size;
      byte _elementsCurrentNb;
-#ifdef RINGBUFFER_STAT
+#ifdef ACTIONRINGBUFFER_STAT
      byte _elementsMaxNb;
      word _lostElementsNb;
 #endif
@@ -49,13 +49,13 @@ class RingBuffer {
   public : 
 
     // Constructor
-    RingBuffer()
+    ActionRingBuffer()
     {
       _head = 0;
       _tail = 0;
       _elementsCurrentNb = 0;
       _size = size;
-    #ifdef RINGBUFFER_STAT
+    #ifdef ACTIONRINGBUFFER_STAT
       _elementsMaxNb = 0; // MAX nb of elements
       _lostElementsNb = 0;    // nb of lost elements
     #endif
@@ -69,14 +69,14 @@ class RingBuffer {
       if (_elementsCurrentNb == _size)
       { // buffer is already full, we overwrite the oldest data
         IncrementHead();
-    #ifdef RINGBUFFER_STAT
+    #ifdef ACTIONRINGBUFFER_STAT
         _lostElementsNb++;
     #endif
       }
       else
       { // we still have some free place
         _elementsCurrentNb++;
-    #ifdef RINGBUFFER_STAT
+    #ifdef ACTIONRINGBUFFER_STAT
         if (_elementsCurrentNb > _elementsMaxNb) _elementsMaxNb++;
     #endif
       }
@@ -101,7 +101,7 @@ class RingBuffer {
     byte ElementsNb(void) const { return _elementsCurrentNb; }
 
 
-    #ifdef RINGBUFFER_STAT
+    #ifdef ACTIONRINGBUFFER_STAT
     // Return Stat information
     void Info(String& str)
     {
@@ -118,4 +118,4 @@ class RingBuffer {
     void IncrementTail(void) { _tail = (_tail + 1) % _size; }
 };
 
-#endif // RINGBUFFER_H
+#endif // ACTIONRINGBUFFER_H

--- a/KnxDevice.cpp
+++ b/KnxDevice.cpp
@@ -19,7 +19,7 @@
 // File : KnxDevice.cpp
 // Author : Franck Marini
 // Description : KnxDevice Abstraction Layer
-// Module dependencies : HardwareSerial, KnxTelegram, KnxComObject, KnxTpUart, RingBuffer
+// Module dependencies : HardwareSerial, KnxTelegram, KnxComObject, KnxTpUart, ActionRingBuffer
 
 #include "KnxDevice.h"
 
@@ -39,7 +39,7 @@ KnxDevice::KnxDevice()
 {
   _state = INIT;
   _tpuart = NULL;
-  _txActionList= RingBuffer<type_tx_action, ACTIONS_QUEUE_SIZE>();
+  _txActionList= ActionRingBuffer<type_tx_action, ACTIONS_QUEUE_SIZE>();
   _initCompleted = false;
   _initIndex = 0;
   _rxTelegram = NULL;

--- a/KnxDevice.h
+++ b/KnxDevice.h
@@ -19,7 +19,7 @@
 // File : KnxDevice.h
 // Author : Franck Marini
 // Description : KnxDevice Abstraction Layer
-// Module dependencies : HardwareSerial, KnxTelegram, KnxComObject, KnxTpUart, RingBuffer
+// Module dependencies : HardwareSerial, KnxTelegram, KnxComObject, KnxTpUart, ActionRingBuffer
 
 #ifndef KNXDEVICE_H
 #define KNXDEVICE_H
@@ -27,7 +27,7 @@
 #include "Arduino.h"
 #include "KnxTelegram.h"
 #include "KnxComObject.h"
-#include "RingBuffer.h"
+#include "ActionRingBuffer.h"
 #include "KnxTpUart.h"
 
 // !!!!!!!!!!!!!!! FLAG OPTIONS !!!!!!!!!!!!!!!!!
@@ -105,7 +105,7 @@ class KnxDevice {
                                                     // The value shall be provided by the end-user
     e_KnxDeviceState _state;                        // Current KnxDevice state
     KnxTpUart *_tpuart;                             // TPUART associated to the KNX Device
-    RingBuffer<type_tx_action, ACTIONS_QUEUE_SIZE> _txActionList; // Queue of transmit actions to be performed
+    ActionRingBuffer<type_tx_action, ACTIONS_QUEUE_SIZE> _txActionList; // Queue of transmit actions to be performed
     boolean _initCompleted;                         // True when all the Com Object with Init attr have been initialized
     byte _initIndex;                                // Index to the last initiated object
     word _lastInitTimeMillis;                       // Time (in msec) of the last init (read) request on the bus

--- a/KnxTpUart.cpp
+++ b/KnxTpUart.cpp
@@ -87,6 +87,8 @@ byte attempts = 10;
 
   // CONFIGURATION OF THE ARDUINO USART WITH CORRECT FRAME FORMAT (19200, 8 bits, parity even, 1 stop bit)
   _serial.begin(19200,SERIAL_8E1);
+  //_serial.begin(19200);
+  //UCSR1C = UCSR1C | B00100000; // Even Parity
   
   while(attempts--)
   { // we send a RESET REQUEST and wait for the reset indication answer

--- a/examples/UnitTests/RingBuffer_UnitTests/RingBuffer_UnitTests.ino
+++ b/examples/UnitTests/RingBuffer_UnitTests/RingBuffer_UnitTests.ino
@@ -1,4 +1,4 @@
-#include <KnxDevice.h> // /!\ Turn "RINGBUFFER_STAT" define on in RingBuffer.h to allow statistics info
+#include <KnxDevice.h> // /!\ Turn "ACTIONRINGBUFFER_STAT" define on in ActionRingBuffer.h to allow statistics info
 #include <Cli.h> // command line interpreter lib available at https://github.com/franckmarini/Cli
 
 Cli cli = Cli(Serial);


### PR DESCRIPTION
Was not that easy to find a new name. But as it is used mainly for actions, ActionRingBuffer would be ok, I guess?

But maybe there is another nice option to resolve that conflict without renaming the header file? 
